### PR TITLE
Adding the required unit tests checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/frontend_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/frontend_template.md
@@ -38,8 +38,7 @@ This section helps reviewers understand the broader context and importance of th
 <!--- If one or more lines do not apply, use ~ to ~strikethrough~ the whole line -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] My code follows the code style of this project.
-- [ ] I have added required unit tests.
-- [ ] I have run tests locally (unit tests).
+- [ ] I have added/updated unit tests.
 - [ ] This has been tested locally (manual).
 - [ ] This has been tested on staging (manual).
 - [ ] My changes require changes in other components/squads/teams

--- a/.github/PULL_REQUEST_TEMPLATE/frontend_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/frontend_template.md
@@ -38,6 +38,7 @@ This section helps reviewers understand the broader context and importance of th
 <!--- If one or more lines do not apply, use ~ to ~strikethrough~ the whole line -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] My code follows the code style of this project.
+- [ ] I have added required unit tests.
 - [ ] I have run tests locally (unit tests).
 - [ ] This has been tested locally (manual).
 - [ ] This has been tested on staging (manual).


### PR DESCRIPTION
### Linked PRs
na

## What does this PR do?

~~It adds a new item the templates checkboxes. The new item asks if the required unit tests are added or not.~~
It changes the checkbox that asks for running unit tests to adding or updating unit tests. We don't ask for running unit tests as they are being run by Github.
It's based on the unit testing task force's [decision](https://docs.google.com/document/d/1skaIddPaiMHf9N-5PE8yWpfZrXGrlRbnTCKFV_ndRng/edit#heading=h.kfjuzqbo6o06).

## Why is this change necessary?

It is a reminder for the frontend developers to consider adding unit tests in their PR if it's applicable.
Having a dedicated section for unit testing is also discussed by the task force but it seems too much.
~~We could also update the checkbox text to include updating the existing unit tests but I think when you run the unit tests and everything is passed, you don't need to update anything, so the checkbox for running tests locally covers this concern.~~

## Associated ticket number and/or AirBrake error?
na

