### PR TITLE
[DPS-MISC] Add DataPi-specific pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/frontend_datapi_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/frontend_datapi_template.md
@@ -1,0 +1,50 @@
+<!--- Provide a general summary of your changes in the Title above -->
+<!-- This is a template, feel free to remove unused sections or add information you think is needed -->
+
+### Linked PRs
+<!-- (Optional) Please list any related PRs here:
+- PR #123 (Title and link)
+- PR #456 (Title and link)
+-->
+
+## What does this PR do?
+<!--- Describe your changes in detail. Explain the process which led you to decide to make the change as you did -->
+
+<!--
+**Before and After Screenshots:**
+- **Before:** ![before](link-to-before-screenshot)
+- **After:** ![after](link-to-after-screenshot)
+-->
+
+## Why is this change necessary?
+<!-- (Optional) Describe the reasoning behind this change. Explain the motivation, the problem it addresses, or the benefits it provides.
+This section helps reviewers understand the broader context and importance of the changes. -->
+
+## Associated ticket number and/or AirBrake error?
+<!--- If this has a related ticket/task, add it here -->
+<!--- Also add any AirBrake errors that will be fixed by this -->
+
+## Due Date or Desirable Merge
+<!-- If you have an idea of the urgency of the PR or would like to inform the reviewers of when you would like to get answers -->
+<!-- Be reasonable and keep in mind that people will not be obligated to answer in your time, but this can be helpful to prioritize reviews -->
+
+<!-- ASAP -->
+<!-- Not urgent -->
+<!-- Next week -->
+<!-- Specific date: [Specify Date] -->
+
+## Checklist
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If one or more lines do not apply, use ~ to ~strikethrough~ the whole line -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] I have added/updated unit tests.
+- [ ] This has been tested locally (manual).
+- [ ] This has been tested on staging (manual).
+- [ ] My changes require changes in other components/squads/teams
+  - [ ] I already did the changes in the other components or notified the responsible people that the changes need to be done
+  - [ ] The needed changes are already deployed or ready to be deployed
+
+### Checklist for DataPi-specific changes
+- [ ] I can assess the usage of my change
+  - [ ] I added mixpanel events to track the usage of my change

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 * [Backend](?expand=1&template=backend_template.md)
 * [Frontend](?expand=1&template=frontend_template.md)
+  * [DataPi](?expand=1&template=frontend_datapi_template.md)
 * [Fullstack](?expand=1&template=fullstack_template.md)
 * [Hotfix](?expand=1&template=hotfix_template.md)
 


### PR DESCRIPTION

## What does this PR do?
<!--- Describe your changes in detail. Explain the process which led you to decide to do the change as you did -->
This PR adds a frontend template for the DataPi squad, which contains a new checklist. This includes a check for mixpanel events.

After a talk with @cebamps, we don't want to include this check for the general frontend template, and that's why I'm going with a new one. We also discussed about adding a new checklist, instead of appending the current one, that is security-focused.

## Due Date or Desirable Merge
<!-- If you have an idea of the urgency of the PR or would like to inform the reviewers of when you would like to get answers -->
<!-- Be reasonable and keep in mind that people will not be obligated to answer in your time, but this can be helpful to prioritize reviews -->
<!-- For example: Needs to be merged before 2024-02-29 | I would like to merge this sometime in the next two weeks | This is super urgent and is blocking this other task, please review ASAP -->
The sooner the better